### PR TITLE
Ensure shell arguments are escaped properly

### DIFF
--- a/lib/fastlane/plugin/xcodegen/actions/xcodegen_action.rb
+++ b/lib/fastlane/plugin/xcodegen/actions/xcodegen_action.rb
@@ -15,14 +15,14 @@ module Fastlane
         end)
 
         cmd = ["xcodegen"]
-        cmd << "--spec #{params[:spec]}" if params[:spec]
-        cmd << "--project #{params[:project]}" if params[:project]
+        cmd += ["--spec", File.expand_path(params[:spec])] if params[:spec]
+        cmd += ["--project", File.expand_path(params[:project])] if params[:project]
         cmd << "--quiet" if params[:quiet]
         cmd << "--use-cache" if params[:use_cache]
-        cmd << "--cache-path #{params[:cache_path]}" if params[:cache_path]
-        cmd << "--project-root #{params[:project_root]}" if params[:project_root]
+        cmd += ["--cache-path", File.expand_path(params[:cache_path])] if params[:cache_path]
+        cmd += ["--project-root", File.expand_path(params[:project_root])] if params[:project_root]
 
-        Actions.sh(cmd.join(' '))
+        Actions.sh(*cmd)
       end
 
       def self.description

--- a/spec/xcodegen_action_spec.rb
+++ b/spec/xcodegen_action_spec.rb
@@ -17,10 +17,10 @@ describe Fastlane do
       end
       it "sets the project param" do
         result = Fastlane::FastFile.new.parse("lane :test do
-            xcodegen(project: '/tmp/Project.xcodeproj')
+            xcodegen(project: '/tmp/My Project.xcodeproj')
           end").runner.execute(:test)
 
-        expect(result).to eq("xcodegen --project /tmp/Project.xcodeproj")
+        expect(result).to eq('xcodegen --project /tmp/My\ Project.xcodeproj')
       end
       it "sets the quiet param" do
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -41,14 +41,15 @@ describe Fastlane do
             xcodegen(cache_path: '~/.xcodegen/cache/MyProject')
           end").runner.execute(:test)
 
-        expect(result).to eq("xcodegen --cache-path ~/.xcodegen/cache/MyProject")
+        cache_path = File.expand_path("~/.xcodegen/cache/MyProject")
+        expect(result).to eq("xcodegen --cache-path #{cache_path}")
       end
       it "sets the project-root param" do
         result = Fastlane::FastFile.new.parse("lane :test do
-            xcodegen(project_root: '../')
+            xcodegen(project_root: '/tmp/project-root')
           end").runner.execute(:test)
 
-        expect(result).to eq("xcodegen --project-root ../")
+        expect(result).to eq("xcodegen --project-root /tmp/project-root")
       end
       it "ignores the quiet and use-cache params if false" do
         result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
👋 

While preparing to to make some changes, i noticed that the command passed into `Actions.sh` was being formed a single string and that none of the arguments were being escaped automatically like you could potentially expect. This is mostly a concern if a path was specified with whitespace for example:

```ruby
xcodegen(project: '/tmp/My Project.xcodeproj')
```

Before, this would invoke `xcodegen --project /tmp/My Project.xcodeproj` where it should be escaped as `xcodegen --project /tmp/My\ Project.xcodeproj` so that the path is treated as a single argument.

There are two ways to perform the escaping:

1. Do it manually using the `shellescape` method (i.e `params[:project].shellescape`)
2. Let the `sh` action do it for us automatically

For `sh` to do this automatically, you pass variable length arguments to the method like so:

```ruby
Actions.sh('xcodegen', '--project', params[:project])
```

But since we form a variable length array of arguments, we can also covert `cmd` to variable list of args using `*` like so:

```ruby
Actions.sh(*cmd)
```

In this change, I do 4 things:

- Make each item in `cmd` an individual argument
- Expand file paths before passing into shell command
  - This has to be done because `~` would have been escaped (since its shell that was expanding it). Instead, the action now handles this using `File.expand_path`
- Pass `cmd` as a variable length argument list (`*cmd`)
- Update specs to include checks for expanded paths and escaped arguments