### PR TITLE
Add `:executable` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ More Information on [_XcodeGen_](https://github.com/yonaskolb/XcodeGen)
 
 ```ruby
   xcodegen(
+	executable: "./bin/xcodegen",
   	spec: "PATH/project.yml",
   	project: "PATH/Project.xcodeproj",
   	quiet: true,

--- a/lib/fastlane/plugin/xcodegen/actions/xcodegen_action.rb
+++ b/lib/fastlane/plugin/xcodegen/actions/xcodegen_action.rb
@@ -12,9 +12,9 @@ module Fastlane
 
           Actions::BrewAction.run(command: "tap yonaskolb/XcodeGen https://github.com/yonaskolb/XcodeGen.git")
           Actions::BrewAction.run(command: "install XcodeGen")
-        end)
+        end) unless params[:executable]
 
-        cmd = ["xcodegen"]
+        cmd = [params[:executable] || "xcodegen"]
         cmd += ["--spec", File.expand_path(params[:spec])] if params[:spec]
         cmd += ["--project", File.expand_path(params[:project])] if params[:project]
         cmd << "--quiet" if params[:quiet]
@@ -42,6 +42,10 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :executable,
+                                       env_name: "XCODEGEN_EXECUTABLE",
+                                       description: "The path to the `xcodegen` executable",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :spec,
                                        env_name: "XCODEGEN_SPEC",
                                        description: "The path to the project spec file",

--- a/spec/xcodegen_action_spec.rb
+++ b/spec/xcodegen_action_spec.rb
@@ -75,6 +75,15 @@ describe Fastlane do
             xcodegen
           end").runner.execute(:test)
       end
+      it "supports a custom executable" do
+        expect(Fastlane::Actions).to_not receive(:sh).with("which xcodegen", anything)
+        expect(Fastlane::Actions::BrewAction).to_not receive(:run)
+        expect(Fastlane::Actions).to receive(:sh).with("./bin/xcodegen", "--quiet")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodegen(executable: './bin/xcodegen', quiet: true)
+        end").runner.execute(:test)
+      end
     end
   end
 end

--- a/spec/xcodegen_action_spec.rb
+++ b/spec/xcodegen_action_spec.rb
@@ -58,6 +58,23 @@ describe Fastlane do
 
         expect(result).to eq("xcodegen")
       end
+      it "attempts to install `xcodegen` using BrewAction if it doesn't exist" do
+        # Expect that `which xcodegen` will fail
+        expect(Fastlane::Actions).to receive(:sh).with("which xcodegen", hash_including(error_callback: anything)) { |command, params|
+          error_callback = params[:error_callback]
+          error_callback.call('xcodegen not found')
+        }
+
+        # Expect that the BrewAction is invoked as expected
+        expect(Fastlane::Actions::BrewAction).to receive(:run).twice
+
+        # And that the original command is then run as expected
+        expect(Fastlane::Actions).to receive(:sh).with("xcodegen")
+
+        Fastlane::FastFile.new.parse("lane :test do
+            xcodegen
+          end").runner.execute(:test)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #3 

**Note: This change depends on #5, I'll rebase this PR after that PR merges. You can view the actual diff [here](https://github.com/NovatecConsulting/fastlane-plugin-xcodegen/pull/6/files/4327fd8f4489187897016ffdda18fb926abafa3c..c83e936d003cb8a0dac4cef3a6588ea3ee315655) in the meantime.**

In this change, I do a couple of things:

1. Add a test to ensure that we install XcodeGen when `which xcodegen` fails
2. Add the `:executable` option, don't attempt to install/check for XcodeGen when set
3. Use the `:executable` value instead of `"xcodegen"` for the command invoked when calling `sh` if set 
4. Add a test to ensure the new behaviour 